### PR TITLE
feat: add issue from issue form to project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -3,6 +3,8 @@ description: File a bug report.
 title: "[🐛]: "
 labels: ["bug"]
 type: "Bug"
+projects:
+  - "spaxel-dev/3"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,6 +3,8 @@ description: Suggest an improvement, enhancement, or new functionality.
 title: "[🚀]: "
 labels: ["enhancement"]
 type: "Feature"
+projects:
+  - "spaxel-dev/3"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -3,6 +3,8 @@ description: For general maintenance, chores, or internal tasks that aren't bug 
 title: "[🧹]: "
 labels: ["chore"]
 type: "Task"
+projects:
+  - "spaxel-dev/3"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## 📝 Summary

This PR updates the template, so that it assigns the issue created with the corresponding issue form to our projects board.

---

## 🔍 What Changed

- added the `projects` property on the templates yaml spec.

---

## 🔗 Related Issue(s)

> [!IMPORTANT]
> Always ensure that you have an existing issue for this respective PR to link with.

Closes #4 

---

## ✅ Checklist

- [x] I’ve tested this locally or in staging
- [x] I’ve updated documentation (if needed)
- [x] I’ve linked relevant issues or discussions
- [x] This is a small, focused change (single concern)
- [x] I’ve followed our [Contribution Guidelines][contributing]

---

[contributing]: https://github.com/spaxel-dev/.github-private/blob/main/profile/CONTRIBUTING.md
